### PR TITLE
Add parallel pipeline for pr

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,43 +1,48 @@
 name: PR Checks
 
 on:
-  # Triggers the workflow on every pull request to master branch
   pull_request:
     branches:
       - main
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build:
+  Prepare Build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: Setup JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 11
           cache: 'gradle'
-
       - name: Set wrapper permission
         run: chmod +x ./gradlew
 
+  Build:
+    runs-on: ubuntu-latest
+    needs: [Prepare Build]
+    steps:
       - name: Assemble Debug
         run: ./gradlew assembleDebug
 
+  Unit Tests:
+    runs-on: ubuntu-latest
+    needs: [Prepare Build]
+    steps:
       - name: Run unit tests
         run: ./gradlew test --stacktrace
 
+  Upload Artifacts:
+    runs-on: ubuntu-latest
+    needs: [Build, Unit Tests]
+    steps:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:
           name: Artifacts
           path: |
-            app/build/reports
-            app/build/outputs/apk/debug/*.apk
+              app/build/reports
+              app/build/outputs/apk/debug/*.apk

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Assemble Debug
         run: ./gradlew assembleDebug
 
+      - name: Upload Apk
+        uses: actions/upload-artifact@v3
+        with:
+          name: Apk
+          path: app/build/outputs/apk/debug/*.apk
+
   Unit-Tests:
     runs-on: ubuntu-latest
     steps:
@@ -51,14 +57,8 @@ jobs:
       - name: Run unit tests
         run: ./gradlew test --stacktrace
 
-  Upload-Artifacts:
-    runs-on: ubuntu-latest
-    needs: [Build, Unit-Tests]
-    steps:
-      - name: Upload
+      - name: Upload Reports
         uses: actions/upload-artifact@v3
         with:
-          name: Artifacts
-          path: |
-              app/build/reports
-              app/build/outputs/apk/debug/*.apk
+          name: Reports
+          path: app/build/reports

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,12 +12,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Setup JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 11
           cache: 'gradle'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
       - name: Set wrapper permission
         run: chmod +x ./gradlew
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  Prepare Build:
+  Prepare-Build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,23 +23,23 @@ jobs:
 
   Build:
     runs-on: ubuntu-latest
-    needs: [Prepare Build]
+    needs: [Prepare-Build]
     steps:
       - name: Assemble Debug
         run: ./gradlew assembleDebug
 
-  Unit Tests:
+  Unit-Tests:
     runs-on: ubuntu-latest
-    needs: [Prepare Build]
+    needs: [Prepare-Build]
     steps:
       - name: Run unit tests
         run: ./gradlew test --stacktrace
 
-  Upload Artifacts:
+  Upload-Artifacts:
     runs-on: ubuntu-latest
-    needs: [Build, Unit Tests]
+    needs: [Build, Unit-Tests]
     steps:
-      - name: Upload Artifacts
+      - name: Upload
         uses: actions/upload-artifact@v3
         with:
           name: Artifacts

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  Prepare-Build:
+  Build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,17 +26,28 @@ jobs:
       - name: Set wrapper permission
         run: chmod +x ./gradlew
 
-  Build:
-    runs-on: ubuntu-latest
-    needs: [Prepare-Build]
-    steps:
       - name: Assemble Debug
         run: ./gradlew assembleDebug
 
   Unit-Tests:
     runs-on: ubuntu-latest
-    needs: [Prepare-Build]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+          cache: 'gradle'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Set wrapper permission
+        run: chmod +x ./gradlew
+
       - name: Run unit tests
         run: ./gradlew test --stacktrace
 


### PR DESCRIPTION
Продолжаю ковырять CI. Сделал паралелльный прогон тестов и сборки вместо последовательного. Пока что это не особо ускоряет из-за того что приложение легкое и тест всего один, но с их ростом будет профит.

<img width="1371" alt="Снимок экрана 2023-02-08 в 15 12 07" src="https://user-images.githubusercontent.com/46102657/217471929-7bd80e8f-9a30-4851-942a-30a239188b7a.png">

Сейчас есть проблемы:
- Зависимости кэшируются неправильно, не переиспользуются по-полной между двумя джобами. Джобы сейчас прогоняются на разных билд агентах (Где-то у гитхаба. Вряд ли это физические машинки, скорее всего из их облака выделяются просто ресурсы) и каждая генерит свои кэши. Нужно сделать общий
- Не кэшируются библиотеки для сборки проекта. Можно поднять прокси где их хранить
- Дублирование шагов в джобах, нужно вынести отдельно и переиспользовать
- Загрузка артефактов кидает архив, удобнее кидать конкретные файлы

Их буду фиксить позже.

@KSVdvlpr комментарии и описание пишу просто для шаринга знаний. Не стоит пытаться в деталях разобраться что и зачем