### PR TITLE
Disable configuration cache for ci

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,7 +17,7 @@ jobs:
         uses: ./.github/actions/prepare-environment
 
       - name: Assemble Debug
-        run: ./gradlew assembleDebug
+        run: ./gradlew assembleDebug --no-configuration-cache
 
       - name: Upload Apk
         uses: actions/upload-artifact@v3
@@ -35,7 +35,7 @@ jobs:
         uses: ./.github/actions/prepare-environment
 
       - name: Run unit tests
-        run: ./gradlew test --stacktrace
+        run: ./gradlew test --stacktrace --no-configuration-cache
 
       - name: Upload Reports
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Кэш конфигурации пока что не умеет шариться между разными машинами и по-факту работает только локально. На CI тратится лишнее время чтобы записать кэш который никогда никто не читает